### PR TITLE
Fix Creatable.Converter.is & add transformers-test

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
 			{
 				"vars": "all",
 				"args": "none",
-				"varsIgnorePattern": "h"
+				"varsIgnorePattern": "^h$"
 			}
 		],
 		"@typescript-eslint/explicit-module-boundary-types": "off",

--- a/Actor.ts
+++ b/Actor.ts
@@ -3,8 +3,6 @@ export class Actor<T extends Actor<T>> {
 	protected readonly transformers: Property.Transformer[] = []
 	constructor(readonly id?: string) {}
 
-	add(...argument: Property.Creatable[]): T
-	add(...argument: (Property.Transformer | undefined)[]): T
 	add(...argument: (Property.Creatable | Property.Transformer | undefined)[]): T {
 		argument.forEach(
 			value =>
@@ -12,6 +10,7 @@ export class Actor<T extends Actor<T>> {
 		)
 		return this as unknown as T
 	}
+
 	private creatableToTransformer(creatable: Property.Creatable): Property.Transformer {
 		return Property.Creatable.Converter.is(creatable)
 			? new Property.Converter(creatable)

--- a/Issuer.ts
+++ b/Issuer.ts
@@ -7,9 +7,7 @@ import { Token } from "./Token"
 
 export class Issuer<T extends Payload> extends Actor<Issuer<T>> {
 	audience?: string | string[]
-	/**
-	 * Duration in seconds
-	 */
+	/** Duration in seconds */
 	duration?: number
 	get header(): Header {
 		return {

--- a/Property/Converter.spec.ts
+++ b/Property/Converter.spec.ts
@@ -1,6 +1,6 @@
+import { isoly } from "isoly"
 import { Converter } from "./Converter"
 import { Creatable } from "./Creatable"
-
 const insideObject = { num: [10, 29, 7], foo: ["here", "test"] }
 
 const conversionMap: Creatable.Converter = {
@@ -21,8 +21,12 @@ const conversionMap: Creatable.Converter = {
 		backward: (value: string) => value.replace("different", ""),
 	},
 	"inside.inside": {
-		forward: ((value: { num: number[]; foo: string[] }) => "NotObject") as Creatable.Converter[string]["backward"],
+		forward: ((value: { num: number[]; foo: string[] }) => "NotObject") as Creatable.Converter[string]["forward"],
 		backward: (value: string) => insideObject,
+	},
+	issued: {
+		forward: (value: string) => isoly.DateTime.epoch(value, "seconds"),
+		backward: (value: number) => isoly.DateTime.create(value),
 	},
 }
 
@@ -31,16 +35,21 @@ const transformObject = {
 	num: 3,
 	inside: { foo: "Value", inside: { num: [10, 29, 7], foo: ["here", "test"] } },
 	arrayMapping: [100, 22, 15],
+	issued: "2023-05-10T10:47:46.000Z",
 }
 const transformedObject = {
 	foo: "Sometransformed",
 	num: 8,
 	inside: { foo: "Valuedifferent", inside: "NotObject" },
 	arrayMapping: [20, 4.4, 3],
+	issued: 1683715666,
 }
 const converter = new Converter(conversionMap)
 
 describe("Converter", () => {
+	it("Converter.is", async () => {
+		expect(Creatable.Converter.is(conversionMap)).toBe(true)
+	})
 	it("Empty Transformmap", async () => {
 		const converter = new Converter({})
 		expect(await converter.apply(transformObject)).toEqual(transformObject)

--- a/Property/Creatable/Converter.ts
+++ b/Property/Creatable/Converter.ts
@@ -5,16 +5,28 @@ type MaybePromise<T> = T | Promise<T>
 type ConverterFunction<V extends Payload.Value> = V extends any
 	? (value: V) => MaybePromise<Payload.Value | undefined>
 	: never
-
 export interface Converter {
 	[key: string]: {
+		/** Returns the value to be included in the jwt. */
 		forward: ConverterFunction<Payload.Value>
+		/** Returns the value to be used in your application. */
 		backward: ConverterFunction<Payload.Value>
 	}
 }
 
 export namespace Converter {
 	export function is(value: Converter | any): value is Converter {
-		return typeof value == "object" && Object.entries(value).every(v => typeof v == "function")
+		return (
+			typeof value == "object" &&
+			Object.values(value).every(
+				v =>
+					v &&
+					typeof v == "object" &&
+					"forward" in v &&
+					typeof v.forward == "function" &&
+					"backward" in v &&
+					typeof v.backward == "function"
+			)
+		)
 	}
 }

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -48,7 +48,7 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 				}
 				result = result && this.verifyAudience(result.aud, audience) ? result : undefined
 				if (result) {
-					const now = Math.floor(Date.now() / 1000)
+					const now = Verifier.now
 					if (result?.iat && result.iat > 1000000000000)
 						result.iat = Math.floor(result.iat / 1000)
 					if (result?.exp && result.exp > 1000000000000)
@@ -79,6 +79,14 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 			? this.verify(authorization.substr(7), ...audience)
 			: undefined
 	}
+	private static get now(): number {
+		return Verifier.staticNow == undefined
+			? Math.floor(Date.now() / 1000)
+			: typeof Verifier.staticNow == "number"
+			? Verifier.staticNow
+			: Math.floor(Verifier.staticNow.getTime() / 1000)
+	}
+	static staticNow: undefined | Date | number
 	static create<T extends Payload>(): Verifier<T>
 	static create<T extends Payload>(...algorithms: Algorithm[]): Verifier<T>
 	static create<T extends Payload>(...algorithms: (Algorithm | undefined)[]): Verifier<T> | undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"eslint": "^8.35.0",
 				"eslint-plugin-prettierx": "github:utily/eslint-plugin-prettierx#utily-20221229",
 				"eslint-plugin-simple-import-sort": "^10.0.0",
+				"isoly": "^2.0.18",
 				"jest": "^29.4.3",
 				"prettierx": "github:utily/prettierx#utily-20221229",
 				"rimraf": "^4.3.0",
@@ -3391,6 +3392,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/isoly": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/isoly/-/isoly-2.0.18.tgz",
+			"integrity": "sha512-dDTKZQyN9jvZWCxcNwBda4tEobkplssPguzCSWrgHZIiz/Dz7/Cv0mEft4J8A2Rrqn42K2ugmOZlqNEt/g7Pdg==",
 			"dev": true
 		},
 		"node_modules/istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"prettierx": "github:utily/prettierx#utily-20221229",
 		"rimraf": "^4.3.0",
 		"ts-jest": "^29.0.5",
-		"typescript": "^4.9.5"
+		"typescript": "^4.9.5",
+		"isoly": "^2.0.18"
 	}
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,7 @@
 		"target": "es6",
 		"module": "es6",
 		"noImplicitAny": true,
-		"removeComments": true,
+		"removeComments": false,
 		"preserveConstEnums": true,
 		"forceConsistentCasingInFileNames": true,
 		"noImplicitThis": true,
@@ -12,7 +12,7 @@
 		"outDir": "dist",
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
-		"esModuleInterop":true,
+		"esModuleInterop": true,
 		"allowJs": true,
 		"plugins": [
 			{


### PR DESCRIPTION
Some documentation and example test with Converter.
Creatable.Converter.is was broken.

Added `authly.Verifier.staticNow` to be able to write tests.

isoly added as devDependency since it is used in tests.