### PR TITLE
check for undefined instead of falsy

### DIFF
--- a/Property/Converter.spec.ts
+++ b/Property/Converter.spec.ts
@@ -65,4 +65,15 @@ describe("Converter", () => {
 	it("Transform Both Ways", async () => {
 		expect(await converter.reverse(await converter.apply(transformObject))).toEqual(transformObject)
 	})
+	it("empty string <---> empty object", async () => {
+		// this conversion is possible with utily/flagly
+		const map: Creatable.Converter = {
+			flagly: {
+				backward: (value: Record<string, unknown>): string => "",
+				forward: (value: string): Record<string, undefined> => ({}),
+			},
+		}
+		const converter = new Converter(map)
+		expect(await converter.apply({ flagly: "" })).toEqual({ flagly: {} })
+	})
 })

--- a/Property/Converter.ts
+++ b/Property/Converter.ts
@@ -25,7 +25,7 @@ export class Converter {
 		fnction: (value: Payload.Value) => Payload.Value | Promise<Payload.Value | undefined> | undefined
 	): Promise<Payload> {
 		const result = { ...payload }
-		if (result[property[0]])
+		if (result[property[0]] != undefined)
 			result[property[0]] =
 				property.length == 1
 					? await fnction(result[property[0]] as Payload)


### PR DESCRIPTION
Converted checked if value was falsy instead of undefined. This caused values `0` and `""` to never be converted. This caused issues when using flagly as empty string should be parsed to empty object.