### PR TITLE
iat leniency for bad system clocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,8 +32,8 @@
 	"editor.formatOnSave": true,
 	"editor.formatOnPaste": true,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true,
-		"eslint.autoFixOnSave": true,
+		"source.fixAll.eslint": "explicit",
+		"eslint.autoFixOnSave": "explicit"
 	},
 	"eslint.format.enable": true,
 	"eslint.lintTask.enable": true,

--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -78,9 +78,9 @@ describe("Verifier", () => {
 		}
 		const verified = {
 			smallDifference: await verifier.verify(signed.smallDifference),
-			big_difference: await verifier.verify(signed.bigDifference),
+			bigDifference: await verifier.verify(signed.bigDifference),
 		}
 		expect(verified.smallDifference).not.toEqual(undefined)
-		expect(verified.big_difference).toEqual(undefined)
+		expect(verified.bigDifference).toEqual(undefined)
 	})
 })

--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -8,7 +8,8 @@ describe("Verifier", () => {
 	const validIssuer = authly.Issuer.create("audience", authly.Algorithm.HS256("secret"))
 	const noneVerifier = authly.Verifier.create(authly.Algorithm.none())
 	const noneIssuer = authly.Issuer.create("audience", authly.Algorithm.none())
-	authly.Issuer.defaultIssuedAt = 1570094329996
+	const defaultIssuedAt = 1570094329996
+	authly.Issuer.defaultIssuedAt = defaultIssuedAt
 	it("undefined", async () => expect(await verifier.verify(undefined, "audience")).toEqual(undefined))
 	it("not a token", async () => expect(await verifier.verify("not a token", "audience")).toEqual(undefined))
 	it("not.a.token", async () => expect(await verifier.verify("not.a.token", "audience")).toEqual(undefined))
@@ -51,5 +52,35 @@ describe("Verifier", () => {
 		expect(jwt).not.toEqual(base64std)
 		expect(verifier && (await verifier.verify(base64url, "audience"))).toBeTruthy()
 		expect(verifier && (await verifier.verify(base64std, "audience"))).toBeTruthy()
+	})
+	it("no vs none algorithm", async () => {
+		const audience = "audience"
+		const defaultIssuedAtSeconds = (authly.Verifier.staticNow = Math.floor(defaultIssuedAt / 1_000))
+		const issuer = authly.Issuer.create(audience, authly.Algorithm.none())
+		const verifiers = {
+			no: authly.Verifier.create(),
+			none: authly.Verifier.create(authly.Algorithm.none()),
+		}
+		const original = { iat: defaultIssuedAtSeconds + 120, foo: "foo" }
+		const signed = await issuer?.sign(original)
+		const verified = {
+			no: await verifiers.no.verify(signed, audience),
+			none: await verifiers.none?.verify(signed, audience),
+		}
+		expect(verified.no).not.toEqual(undefined)
+		expect(verified.none).toEqual(undefined)
+	})
+	it("leniency", async () => {
+		const defaultIssuedAtSeconds = (authly.Verifier.staticNow = Math.floor(defaultIssuedAt / 1_000))
+		const signed = {
+			smallDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds + 30 }),
+			bigDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds + 120 }),
+		}
+		const verified = {
+			smallDifference: await verifier.verify(signed.smallDifference),
+			big_difference: await verifier.verify(signed.bigDifference),
+		}
+		expect(verified.smallDifference).not.toEqual(undefined)
+		expect(verified.big_difference).toEqual(undefined)
 	})
 })

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -45,7 +45,7 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 					if (result?.exp && result.exp > 1000000000000)
 						result.exp = Math.floor(result.exp / 1000)
 					result =
-						(result.exp == undefined || result.exp > now) && (result.iat == undefined || result.iat <= now)
+						(result.exp == undefined || result.exp > now) && (result.iat == undefined || result.iat <= now + 60)
 							? result
 							: undefined
 				}

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -46,7 +46,6 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 						result.exp = Math.floor(result.exp / 1000)
 					result =
 						!this.algorithms ||
-						"none" in this.algorithms ||
 						((result.exp == undefined || result.exp > now) && (result.iat == undefined || result.iat <= now + 60))
 							? result
 							: undefined

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -45,7 +45,9 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 					if (result?.exp && result.exp > 1000000000000)
 						result.exp = Math.floor(result.exp / 1000)
 					result =
-						(result.exp == undefined || result.exp > now) && (result.iat == undefined || result.iat <= now + 60)
+						!this.algorithms ||
+						"none" in this.algorithms ||
+						((result.exp == undefined || result.exp > now) && (result.iat == undefined || result.iat <= now + 60))
 							? result
 							: undefined
 				}


### PR DESCRIPTION
* Added +60 seconds to the `issued at` to provide some leniency to system clock being off by some seconds.
`expire` is left as.
* If no algorithm is provided the check for `expire` / `issued at` is skipped.