### PR TITLE
stricter verify + unpack

### DIFF
--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -55,32 +55,37 @@ describe("Verifier", () => {
 	})
 	it("no vs none algorithm", async () => {
 		const audience = "audience"
-		const defaultIssuedAtSeconds = (authly.Verifier.staticNow = Math.floor(defaultIssuedAt / 1_000))
 		const issuer = authly.Issuer.create(audience, authly.Algorithm.none())
 		const verifiers = {
 			no: authly.Verifier.create(),
 			none: authly.Verifier.create(authly.Algorithm.none()),
 		}
-		const original = { iat: defaultIssuedAtSeconds + 120, foo: "foo" }
+		const original = { iat: defaultIssuedAt, foo: "foo" }
 		const signed = await issuer?.sign(original)
 		const verified = {
 			no: await verifiers.no.verify(signed, audience),
 			none: await verifiers.none?.verify(signed, audience),
 		}
-		expect(verified.no).not.toEqual(undefined)
-		expect(verified.none).toEqual(undefined)
+		expect(verified.no).toEqual(undefined)
+		expect(verified.none).not.toEqual(undefined)
 	})
 	it("leniency", async () => {
 		const defaultIssuedAtSeconds = (authly.Verifier.staticNow = Math.floor(defaultIssuedAt / 1_000))
 		const signed = {
-			smallDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds + 30 }),
-			bigDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds + 120 }),
+			bigNegativeDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds - 120 }),
+			smallNegativeDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds - 30 }),
+			smallPositiveDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds + 30 }),
+			bigPositiveDifference: await validIssuer.sign({ iat: defaultIssuedAtSeconds + 120 }),
 		}
 		const verified = {
-			smallDifference: await verifier.verify(signed.smallDifference),
-			bigDifference: await verifier.verify(signed.bigDifference),
+			bigNegativeDifference: await verifier.verify(signed.bigPositiveDifference),
+			smallNegativeDifference: await verifier.verify(signed.smallPositiveDifference),
+			smallPositiveDifference: await verifier.verify(signed.smallPositiveDifference),
+			bigPositiveDifference: await verifier.verify(signed.bigPositiveDifference),
 		}
-		expect(verified.smallDifference).not.toEqual(undefined)
-		expect(verified.bigDifference).toEqual(undefined)
+		expect(verified.bigNegativeDifference).toEqual(undefined)
+		expect(verified.smallNegativeDifference).not.toEqual(undefined)
+		expect(verified.smallPositiveDifference).not.toEqual(undefined)
+		expect(verified.bigPositiveDifference).toEqual(undefined)
 	})
 })

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -23,7 +23,7 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 		token: string | Token | undefined
 	): Promise<{ header: Header; payload: Payload; signature: string; splitted: [string, string, string] } | undefined> {
 		let result: Awaited<ReturnType<Verifier<T>["decode"]>>
-		const splitted = token?.split(".")
+		const splitted = token?.split(".", 3)
 		if (splitted?.length != 3)
 			result = undefined
 		else {

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -1,4 +1,4 @@
-import { Base64, TextDecoder } from "cryptly"
+import { cryptly } from "cryptly"
 import { Actor } from "./Actor"
 import { Algorithm } from "./Algorithm"
 import { Header } from "./Header"
@@ -19,49 +19,65 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 		} else
 			this.algorithms = undefined
 	}
-	async verify(token: string | Token | undefined, ...audience: string[]): Promise<T | undefined> {
-		let result: Payload | undefined = undefined
-		if (token) {
-			const splitted = token.split(".", 3)
-			if (splitted.length == 3) {
-				try {
-					const oldDecoder = token.includes("/") || token.includes("+") // For backwards compatibility.
-					const header: Header = JSON.parse(
-						new TextDecoder().decode(Base64.decode(splitted[0], oldDecoder ? "standard" : "url"))
-					)
-					if (await this.verifySignature(header, splitted)) {
-						result = JSON.parse(
-							new TextDecoder().decode(Base64.decode(splitted[1], oldDecoder ? "standard" : "url"))
-						) as Payload
-					}
-				} catch {
-					// Keep result undefined
-				}
-				result = result && this.verifyAudience(result.aud, audience) ? result : undefined
-				if (result) {
-					const now = Verifier.now
-					if (result?.iat && result.iat > 1000000000000)
-						result.iat = Math.floor(result.iat / 1000)
-					if (result?.exp && result.exp > 1000000000000)
-						result.exp = Math.floor(result.exp / 1000)
-					result =
-						!this.algorithms ||
-						((result.exp == undefined || result.exp > now) && (result.iat == undefined || result.iat <= now + 60))
-							? result
-							: undefined
-				}
-				if (result) {
-					result.token = token
-					result = await this.transformers.reduceRight(async (p, c) => c.reverse(await p), Promise.resolve(result))
-				}
+	private async decode(
+		token: string | Token | undefined
+	): Promise<{ header: Header; payload: Payload; signature: string; splitted: [string, string, string] } | undefined> {
+		let result: Awaited<ReturnType<Verifier<T>["decode"]>>
+		const splitted = token?.split(".")
+		if (splitted?.length != 3)
+			result = undefined
+		else {
+			try {
+				const standard: cryptly.Base64.Standard = token?.match(/[/+]/) ? "standard" : "url"
+				const decoder = new cryptly.TextDecoder()
+				const header: Header = JSON.parse(decoder.decode(cryptly.Base64.decode(splitted[0], standard)))
+				const payload: Payload | undefined = JSON.parse(
+					decoder.decode(cryptly.Base64.decode(splitted[1], standard))
+				) as Payload
+				if (payload.iat && payload.iat > 1000000000000)
+					payload.iat = Math.floor(payload.iat / 1000)
+				if (payload.exp && payload.exp > 1000000000000)
+					payload.exp = Math.floor(payload.exp / 1000)
+				payload.token = token
+				result = !payload
+					? undefined
+					: { header, payload, signature: splitted[0], splitted: [splitted[0], splitted[1], splitted[2]] }
+			} catch {
+				result = undefined
 			}
 		}
+		return result
+	}
+	private async transform(payload: Payload | undefined): Promise<T | undefined> {
+		const result = await this.transformers.reduceRight(async (p, c) => c.reverse(await p), Promise.resolve(payload))
 		return result as T | undefined
+	}
+	async unpack(token: string | Token | undefined): Promise<T | undefined> {
+		return await this.transform((await this.decode(token))?.payload)
+	}
+	async verify(token: string | Token | undefined, ...audience: string[]): Promise<T | undefined> {
+		let result: T | undefined
+		const decoded = await this.decode(token)
+		const now = Verifier.now
+		if (!decoded)
+			result = undefined
+		else if (!(await this.verifySignature(decoded.header, decoded.splitted)))
+			result = undefined
+		else if (!this.verifyAudience(decoded.payload.aud, audience))
+			result = undefined
+		else if (
+			!(decoded.payload.exp == undefined || decoded.payload.exp > now) ||
+			!(decoded.payload.iat == undefined || decoded.payload.iat <= now + 60 || decoded.payload.iat <= now - 60)
+		)
+			result = undefined
+		else
+			result = await this.transform(decoded.payload)
+		return result
 	}
 	private async verifySignature(header: Header, splitted: string[]): Promise<boolean> {
 		let result = false
 		if (this.algorithms) {
-			const algorithms = this.algorithms[header.alg]
+			const algorithms = this.algorithms[header.alg] ?? []
 			for (const currentAlgorithm of algorithms) {
 				if (await currentAlgorithm.verify(`${splitted[0]}.${splitted[1]}`, splitted[2])) {
 					result = true
@@ -83,26 +99,6 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 		return authorization && authorization.startsWith("Bearer ")
 			? this.verify(authorization.substr(7), ...audience)
 			: undefined
-	}
-	async unpack(token: string | Token | undefined): Promise<T | undefined> {
-		let result: Payload | undefined
-		const splitted = token?.split(".")
-		if (!splitted)
-			result = undefined
-		else {
-			try {
-				result = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[1], "url"))) as Payload
-				if (result.iat)
-					result.iat = Math.floor(result.iat / 1000)
-				if (result.exp)
-					result.exp = Math.floor(result.exp / 1000)
-				result.token = token
-				result = await this.transformers.reduceRight(async (p, c) => c.reverse(await p), Promise.resolve(result))
-			} catch {
-				result = undefined
-			}
-		}
-		return result as T | undefined
 	}
 	private static get now(): number {
 		return Verifier.staticNow == undefined

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -41,7 +41,7 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 				payload.token = token
 				result = !payload
 					? undefined
-					: { header, payload, signature: splitted[0], splitted: [splitted[0], splitted[1], splitted[2]] }
+					: { header, payload, signature: splitted[2], splitted: [splitted[0], splitted[1], splitted[2]] }
 			} catch {
 				result = undefined
 			}

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -31,9 +31,7 @@ export class Verifier<T extends Payload> extends Actor<Verifier<T>> {
 				const standard: cryptly.Base64.Standard = token?.match(/[/+]/) ? "standard" : "url"
 				const decoder = new cryptly.TextDecoder()
 				const header: Header = JSON.parse(decoder.decode(cryptly.Base64.decode(splitted[0], standard)))
-				const payload: Payload | undefined = JSON.parse(
-					decoder.decode(cryptly.Base64.decode(splitted[1], standard))
-				) as Payload
+				const payload: Payload = JSON.parse(decoder.decode(cryptly.Base64.decode(splitted[1], standard)))
 				if (payload.iat && payload.iat > 1000000000000)
 					payload.iat = Math.floor(payload.iat / 1000)
 				if (payload.exp && payload.exp > 1000000000000)

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -102,15 +102,13 @@ describe("authly", () => {
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJpc3N1ZXIiLCJpYXQiOjQ5MDYyLCJhdWQiOlsidmVyaWZpZXIiLCJhdWRpZW5jZSJdLCJ0ZXN0IjoidGVzdCJ9.BxRECvB1umtdTIs7FsiCPcw7y-nPob2rCK-nC4WHwew"
 		const verifier = authly.Verifier.create()
 		expect(verifier).toBeTruthy()
-		if (verifier) {
-			expect(await verifier.verify(token)).toEqual({
-				iss: "issuer",
-				aud: ["verifier", "audience"],
-				iat: 49062,
-				test: "test",
-				token,
-			})
-		}
+		expect(await verifier.unpack(token)).toEqual({
+			iss: "issuer",
+			aud: ["verifier", "audience"],
+			iat: 49062,
+			test: "test",
+			token,
+		})
 	})
 	it("HS256 + property encryption", async () => {
 		const algorithm = authly.Algorithm.HS256("secret-key")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "authly",
-	"version": "3.0.13",
+	"version": "3.1.0",
 	"description": "Tokenized authentication using JSON Web Tokens with support for encrypted token properties.",
 	"author": "Utily Contributors",
 	"license": "MIT",


### PR DESCRIPTION
* Verification always fails if no algorithm is specified
* Implemented `Verifier.unpack()` method
* Refactored out common logic from unpack / verify into two new private method `Verifier.decode(...)` and `Verifier.transform(...)`

The stricter verification is backwards incompatible. 